### PR TITLE
Implemented the following plugins:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# Whole File ingest
+
+
+Description
+-----------
+The whole file ingest plugins consist of sources and sinks that can copy data between different filesystems.
+
+Use Case
+--------
+Use these plugins to create a pipeline that synchrnizes files in your local HDFS periodically with an Amazon S3 filesystem.
+ 
+Build
+-----
+To build your plugins:
+
+    mvn clean package -DskipTests
+
+The build will create a .jar and .json file under the ``target`` directory.
+These files can be used to deploy your plugins.
+
+UI Integration
+--------------
+The CDAP UI displays each plugin property as a simple textbox. To customize how the plugin properties
+are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
+The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
+
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/hydrator-manual/developing-plugins/packaging-plugins.html#plugin-widget-json)
+for details on the configuration file.
+
+The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
+that follows the convention of ``[plugin-name]-[plugin-type].md``.
+
+When the build runs, it will scan the ``widgets`` and ``docs`` directories in order to build an appropriately
+formatted .json file under the ``target`` directory. This file is deployed along with your .jar file to add your
+plugins to CDAP.
+
+Deployment
+----------
+You can deploy your plugins using the CDAP CLI:
+
+    > load artifact <target/plugin.jar> config-file <target/plugin.json>
+
+For example, here if your artifact is named 'azure-decompress-action-1.0.0.jar':
+
+    > load artifact target/azure-decompress-action-1.0.0.jar config-file target/azure-decompress-action-1.0.0.json
+
+## Mailing Lists
+
+CDAP User Group and Development Discussions:
+
+- `cdap-user@googlegroups.com <https://groups.google.com/d/forum/cdap-user>`__
+
+The *cdap-user* mailing list is primarily for users using the product to develop
+applications or building plugins for appplications. You can expect questions from 
+users, release announcements, and any other discussions that we think will be helpful 
+to the users.
+
+## IRC Channel
+
+CDAP IRC Channel: #cdap on irc.freenode.net
+
+
+## License and Trademarks
+
+Copyright © 2016-2017 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2014-2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!-- This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html -->
+
+<module name="Checker">
+
+  <module name="FileTabCharacter">
+    <property name="severity" value="error"/>
+    <!-- Checks that there are no tab characters in the file.
+    -->
+  </module>
+
+  <!--
+
+  LENGTH CHECKS FOR FILES
+
+  -->
+
+  <module name="FileLength">
+    <property name="max" value="3000"/>
+    <property name="severity" value="warning"/>
+  </module>
+
+
+  <module name="NewlineAtEndOfFile">
+    <property name="lineSeparator" value="lf"/>
+  </module>
+
+  <module name="RegexpSingleline">
+    <!-- Checks that FIXME is not used in comments.  TODO is preferred.
+    -->
+    <property name="format" value="((//.*)|(\*.*))FIXME" />
+    <property name="message" value='TODO is preferred to FIXME.  e.g. "TODO: (ENG-123) -  Refactor when v2 is released."' />
+  </module>
+
+  <module name="RegexpSingleline">
+    <!-- Checks that TODOs are named with some basic formatting. Checks for the following pattern  TODO: ( 
+    -->
+    <property name="format" value="((//.*)|(\*.*))TODO[^: (]" />
+    <property name="message" value='All TODOs should be named.  e.g. "TODO: (ENG-123) - Refactor when v2 is released."' />
+  </module>
+
+  <module name="JavadocPackage">
+    <!-- Checks that each Java package has a Javadoc file used for commenting.
+      Only allows a package-info.java, not package.html. -->
+    <property name="severity" value="error"/>
+  </module>
+
+  <!-- All Java AST specific tests live under TreeWalker module. -->
+  <module name="TreeWalker">
+
+    <!-- required for SupressionCommentFilter and SuppressWithNearbyCommentFilter -->
+    <module name="FileContentsHolder"/>
+
+    <!--
+
+    IMPORT CHECKS
+
+    -->
+
+    <module name="AvoidStarImport">
+      <property name="allowClassImports" value="false"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="RedundantImport">
+      <!-- Checks for redundant import statements. -->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="ImportOrder">
+      <!-- Checks for out of order import statements. -->
+      <property name="severity" value="error"/>
+      <property name="ordered" value="true"/>
+      <property name="groups" value="/([^j]|.[^a]|..[^v]|...[^a])/,/^javax?\./"/>
+      <!-- This ensures that static imports go to the end. -->
+      <property name="option" value="bottom"/>
+      <property name="tokens" value="STATIC_IMPORT, IMPORT"/>
+    </module>
+
+    <module name="IllegalImport">
+      <property name="illegalPkgs" value="junit.framework"/>
+    </module>
+
+    <!--
+
+    METHOD LENGTH CHECKS
+
+    -->
+
+    <module name="MethodLength">
+      <property name="tokens" value="METHOD_DEF"/>
+      <property name="max" value="300"/>
+      <property name="countEmpty" value="false"/>
+      <property name="severity" value="warning"/>
+   </module>
+   
+    <!--
+
+    JAVADOC CHECKS
+
+    -->
+
+    <!-- Checks for Javadoc comments.                     -->
+    <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+    <module name="JavadocMethod">
+      <property name="scope" value="protected"/>
+      <property name="severity" value="error"/>
+      <property name="allowMissingJavadoc" value="true"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowMissingThrowsTags" value="true"/>
+      <property name="allowThrowsTagsForSubclasses" value="true"/>
+      <property name="allowUndeclaredRTE" value="true"/>
+    </module>
+
+    <module name="JavadocType">
+      <property name="scope" value="protected"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="JavadocStyle">
+      <property name="severity" value="error"/>
+    </module>
+
+    <!--
+
+    NAMING CHECKS
+
+    -->
+
+    <!-- Item 38 - Adhere to generally accepted naming conventions -->
+
+    <module name="PackageName">
+      <!-- Validates identifiers for package names against the
+        supplied expression. -->
+      <!-- Here the default checkstyle rule restricts package name parts to
+        seven characters, this is not in line with common practice at Google.
+      -->
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="TypeNameCheck">
+      <!-- Validates static, final fields against the
+      expression "^[A-Z][a-zA-Z0-9]*$". -->
+      <metadata name="altname" value="TypeName"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="ConstantNameCheck">
+      <!-- Validates non-private, static, final fields against the supplied
+      public/package final fields "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$". -->
+      <metadata name="altname" value="ConstantName"/>
+      <property name="applyToPublic" value="true"/>
+      <property name="applyToProtected" value="true"/>
+      <property name="applyToPackage" value="true"/>
+      <property name="applyToPrivate" value="false"/>
+      <property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|FLAG_.*)$"/>
+      <message key="name.invalidPattern"
+               value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)."/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="StaticVariableNameCheck">
+      <!-- Validates static, non-final fields against the supplied
+      expression "^[a-z][a-zA-Z0-9]*_?$". -->
+      <metadata name="altname" value="StaticVariableName"/>
+      <property name="applyToPublic" value="true"/>
+      <property name="applyToProtected" value="true"/>
+      <property name="applyToPackage" value="true"/>
+      <property name="applyToPrivate" value="true"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*_?$"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="MemberNameCheck">
+      <!-- Validates non-static members against the supplied expression. -->
+      <metadata name="altname" value="MemberName"/>
+      <property name="applyToPublic" value="true"/>
+      <property name="applyToProtected" value="true"/>
+      <property name="applyToPackage" value="true"/>
+      <property name="applyToPrivate" value="true"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="MethodNameCheck">
+      <!-- Validates identifiers for method names. -->
+      <metadata name="altname" value="MethodName"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="ParameterName">
+      <!-- Validates identifiers for method parameters against the
+        expression "^[a-z][a-zA-Z0-9]*$". -->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="LocalFinalVariableName">
+      <!-- Validates identifiers for local final variables against the
+        expression "^[a-z][a-zA-Z0-9]*$". -->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="LocalVariableName">
+      <!-- Validates identifiers for local variables against the
+        expression "^[a-z][a-zA-Z0-9]*$". -->
+      <property name="severity" value="error"/>
+    </module>
+
+
+    <!--
+
+    LENGTH and CODING CHECKS
+
+    -->
+
+    <module name="LineLength">
+      <!-- Checks if a line is too long. -->
+      <property name="max" value="120" default="120"/>
+      <property name="severity" value="error"/>
+
+      <!--
+        The default ignore pattern exempts the following elements:
+          - import statements
+          - long URLs inside comments
+      -->
+
+      <property name="ignorePattern"
+          value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.ignorePattern}"
+          default="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)$"/>
+    </module>
+
+    <module name="LeftCurly">
+      <!-- Checks for placement of the left curly brace ('{'). -->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="RightCurly">
+      <!-- Checks right curlies on CATCH, ELSE, and TRY blocks are on
+      the same line. e.g., the following example is fine:
+      <pre>
+        if {
+          ...
+        } else
+      </pre>
+      -->
+      <!-- This next example is not fine:
+      <pre>
+        if {
+          ...
+        }
+        else
+      </pre>
+      -->
+      <property name="option" value="same"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <!-- Checks for braces around if and else blocks -->
+    <module name="NeedBraces">
+      <property name="severity" value="error"/>
+      <property name="tokens" value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
+    </module>
+
+    <module name="UpperEll">
+      <!-- Checks that long constants are defined with an upper ell.-->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="FallThrough">
+      <!-- Warn about falling through to the next case statement.  Similar to
+      javac -Xlint:fallthrough, but the check is suppressed if a single-line comment
+      on the last non-blank line preceding the fallen-into case contains 'fall through' (or
+      some other variants which we don't publicized to promote consistency).
+      -->
+      <property name="reliefPattern"
+       value="fall through|Fall through|fallthru|Fallthru|falls through|Falls through|fallthrough|Fallthrough|No break|NO break|no break|continue on"/>
+      <property name="severity" value="error"/>
+    </module>
+
+
+    <!--
+
+    MODIFIERS CHECKS
+
+    -->
+
+    <module name="ModifierOrder">
+      <!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
+           8.4.3.  The prescribed order is:
+           public, protected, private, abstract, static, final, transient, volatile,
+           synchronized, native, strictfp
+        -->
+    </module>
+
+    <module name="RedundantModifier">
+      <!-- Checks for redundant modifiers in:
+           - interface and annotation definitions,
+           - the final modifier on methods of final classes, and
+           - inner interface declarations that are declared as static.
+        -->
+    </module>
+
+
+    <!--
+
+    WHITESPACE CHECKS
+
+    -->
+    <module name="GenericWhitespace"/>
+
+    <module name="WhitespaceAround">
+      <!-- Checks that various tokens are surrounded by whitespace.
+           This includes most binary operators and keywords followed
+           by regular or curly braces.
+      -->
+      <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR,
+        BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
+        EQUAL, GE, GT, LAND, LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+        LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+        LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
+        MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
+        SL, SLIST, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN"/>
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="WhitespaceAfter">
+      <!-- Checks that commas, semicolons and typecasts are followed by
+           whitespace.
+      -->
+      <property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="NoWhitespaceAfter">
+      <!-- Checks that there is no whitespace after various unary operators.
+           Linebreaks are allowed.
+      -->
+      <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
+        UNARY_PLUS"/>
+      <property name="allowLineBreaks" value="true"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="NoWhitespaceBefore">
+      <!-- Checks that there is no whitespace before various unary operators.
+           Linebreaks are allowed.
+      -->
+      <property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
+      <property name="allowLineBreaks" value="true"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="ParenPad">
+      <!-- Checks that there is no whitespace before close parens or after
+           open parens.
+      -->
+      <property name="severity" value="error"/>
+    </module>
+
+  </module>
+
+  <!--
+    Optional suppression filter. It is optional because when running with Maven, it should be the
+     checkstyle plugin who provides it. It is only used when this file is used in IntelliJ.
+    -->
+
+  <module name="SuppressionFilter">
+    <property name="file" value="suppressions.xml"/>
+    <property name="optional" value="true"/>
+  </module>
+
+  <module name="SuppressionCommentFilter">
+    <property name="offCommentFormat" value="CHECKSTYLE OFF: (.+)" />
+    <property name="onCommentFormat" value="CHECKSTYLE ON" />
+    <property name="checkFormat" value="Javadoc.*"/>
+    <property name="messageFormat" value="$1"/>
+  </module>
+
+</module>

--- a/docs/HDFSFileCopySink-batchsink.md
+++ b/docs/HDFSFileCopySink-batchsink.md
@@ -1,0 +1,41 @@
+# HDfS File Copy Batch Sink
+
+Description
+-----------
+The HDFS File Copy plugin is a sink plugin that takes file metadata records as inputs and copies the files into local HDFS
+
+
+Use Case
+--------
+Use this sink to copy files from any source to your local HDFS.
+You may want to periodically sync your HDFS with some remote filesystem. Schedule to run a pipeline with this plugin to copy new files periodically.
+
+
+Properties
+----------
+| Configuration                            | Required | Default   | Description                                                                                                                  |
+| :--------------------------------------- | :------: | :------   | :--------------------------------------------------------------------------------------------------------------------------- |
+| **Reference Name**                       |  **Y**   | None      | This will be used to uniquely identify this source for lineage, annotating metadata, etc.                                    |
+| **Base Path**                            |  **Y**   | None      | The folder where the copied files will be placed. It will be created if it doesn't exist.                                    |
+| **Enable Overwrite**                     |  **Y**   | False     | Specifies whether or not to overwrite files if it already exists.                                                            |
+| **Preserve File Owner**                  |  **Y**   | False     | Whether or not to preserve the owner of the file from source filesystem.                                                     |
+| **Buffer Size**                          |  **Y**   | 1 MB      | The size of the buffer (in MegaBytes) that temporarily stores data from file input stream while copying. Defaults to 1 MB.   |
+
+Usage Notes
+-----------
+This sink plugin only reads StructuredRecords with the following schema. Each record should contain the metadata for a file to be copied
+
+| Field                  | Type   | Description                                                                                                                                    |
+| :--------------------- | :----- | :-------------------------                                                                                                                     |
+| **fileName**           | String | Only contains the name of the file.                                                                                                            |
+| **fullPath**           | String | Contains the full path of the file in the source file system.                                                                                  |
+| **fileSize**           | long   | File size in bytes.                                                                                                                            |
+| **hostURI**            | String | The source filesystem's URI.                                                                                                                   |
+| **modificationTime**   | long   | The modification timestamp of the file.                                                                                                        |
+| **group**              | String | The group that the of the file belongs to.                                                                                                     |
+| **owner**              | String | The owner of the file.                                                                                                                         |
+| **isFolder**           | Boolean| Whether or not the file is a folder.                                                                                                           |
+| **relativePath**       | String | The relative path is constructed by deleting the portion of the source path that comes before the last path separator ("/") from the full path.|
+| **filesystem**         | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
+| **permission**         | int    | The file's access permission                                                                                                                   |
+| **Credentials**        | Record | Additional information required to connect to the source Filesystem.                                                                           |

--- a/docs/S3FileMetadataSource-batchsource.md
+++ b/docs/S3FileMetadataSource-batchsource.md
@@ -1,0 +1,47 @@
+# S3 File Metadata Batch Source
+
+Description
+-----------
+The S3 File Metadata plugin is a source plugin that allows users to read file metadata from an S3 Filesystem.
+
+
+Use Case
+--------
+Use this source to extract the metadata of files under specified paths. The metadata can be passed to the
+HDFSFileCopySink and the files will be copied from S3 to HDFS
+
+
+Properties
+----------
+| Configuration          | Required | Default   | Description                                                                                                                                                                                                                                                                     |
+| :--------------------- | :------: | :------   | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Reference Name**     |  **Y**   | None      | This will be used to uniquely identify this source for lineage, annotating metadata, etc.                                                                                                                                                                                       |
+| **Source Paths**       |  **Y**   | None      | Path(s) to file(s) to be read. If a directory is specified, terminate the path name with a '/'.                                                                                                                                                                                 |
+| **Max Split Size**     |  **Y**   | None      | Specifies the number of files that are controlled by each split. The number of splits created will be the total number of files divided by Max Split Size. The InputFormat will assign roughly the same number of bytes to each split.                                          |
+| **Host URI**           |  **Y**   | None      | URI of the bucket which you want to read from. For example, if you want to read from s3 bucket `example.bucket.co`, this configuration would be `s3a://example.bucket.co`                                                                                                       |
+| **Copy Recursively**   |  **Y**   | True      | Whether or not to copy recursively. Similar to the `-r` option in the `cp` terminal command. Set this to true if you want to copy the entire directory recursively.                                                                                                             |
+| **Access Key ID**      |  **Y**   | None      | Your Amazon S3 access key ID.                                                                                                                                                                                                                                                   |
+| **Secret Key ID**      |  **Y**   | None      | Your Amazon S3 secret key ID.                                                                                                                                                                                                                                                   |
+| **Amazon Region**      |  **N**   | us-east-1 | Region of the bucket which you want to read from.                                                                                                                                                                                                                               |
+
+Usage Notes
+-----------
+This source plugin only reads filemetadata from the source. To copy files, pass its outputs to a FileCopySink of the desired Filesystem.
+A structured record with the following schema is emitted for each file it reads.
+
+| Field                  | Type   | Description                                                                                                                                    |
+| :--------------------- | :----- | :-------------------------                                                                                                                     |
+| **fileName**           | String | Only contains the name of the file.                                                                                                            |
+| **fullPath**           | String | Contains the full path of the file in the source file system.                                                                                  |
+| **fileSize**           | long   | File Szie in bytes.                                                                                                                            |
+| **hostURI**            | String | The source filesystem's URI.                                                                                                                   |
+| **modificationTime**   | long   | The modification timestamp of the file.                                                                                                        |
+| **group**              | String | The group that the of the file belongs to.                                                                                                     |
+| **owner**              | String | The owner of the file.                                                                                                                         |
+| **isFolder**           | Boolean| Whether or not the file is a folder.                                                                                                           |
+| **relativePath**       | String | The relative path is constructed by deleting the portion of the source path that comes before the last path separator ("/") from the full path.|
+| **filesystem**         | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
+| **permission**         | int    | The file's access permission                                                                                                                   |
+| **accessKeyID**        | String | Access Key ID for the source Filesystem.                                                                                                       |
+| **secretKeyID**        | String | Secret Key ID for the source Filesystem.                                                                                                       |
+| **region**             | String | Region of the source Filesystem.                                                                                                               |

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <scope>provided</scope>
       <version>${hadoop.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2017 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Whole File Ingest Plugins</name>
+  <groupId>co.cask.hydrator</groupId>
+  <artifactId>whole-file-ingest</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>A business-friendly OSS license</comments>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Cask Data</name>
+      <email>cask-dev@googlegroups.com</email>
+      <organization>Cask Data, Inc.</organization>
+      <organizationUrl>http://www.cask.co</organizationUrl>
+    </developer>
+  </developers>
+
+  <issueManagement>
+    <url>https://issues.cask.co/browse/HYDRATOR</url>
+  </issueManagement>
+
+  <distributionManagement>
+    <repository>
+      <id>sonatype.release</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype.snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <site>
+      <id>cask</id>
+      <url>http://cask.co</url>
+    </site>
+  </distributionManagement>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <cdap.version>4.3.0-SNAPSHOT</cdap.version>
+    <hadoop.version>2.8.1</hadoop.version>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <widgets.dir>widgets</widgets.dir>
+    <docs.dir>docs</docs.dir>
+    <app.parents>system:cdap-data-pipeline[4.3.0-SNAPSHOT,4.4.0-SNAPSHOT),system:cdap-data-streams[4.3.0-SNAPSHOT,4.4.0-SNAPSHOT)</app.parents>
+    <!-- this is here because project.basedir evaluates to null in the script build step -->
+    <main.basedir>${project.basedir}</main.basedir>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+    </repository>
+    <repository>
+      <id>sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-api</artifactId>
+      <version>${cdap.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>hydrator-test</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14.1</version>
+        <configuration>
+          <argLine>-Xmx5000m -Djava.awt.headless=true -XX:MaxPermSize=1024m -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError="kill -9 %p" -Djava.net.preferIPv4Stack=true</argLine>
+          <reuseForks>false</reuseForks>
+          <reportFormat>plain</reportFormat>
+          <systemPropertyVariables>
+            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+          </systemPropertyVariables>
+          <includes>
+            <include>**/*TestsSuite.java</include>
+            <include>**/*TestSuite.java</include>
+            <include>**/Test*.java</include>
+            <include>**/*Test.java</include>
+            <include>**/*TestCase.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/*TestRun.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.4</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+            <!--Only @Plugin classes in the export packages will be included as plugin-->
+            <_exportcontents>co.cask.hydrator.*</_exportcontents>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>process-test-classes</phase>
+            <configuration>
+              <configLocation>checkstyle.xml</configLocation>
+              <suppressionsLocation>suppressions.xml</suppressionsLocation>
+              <encoding>UTF-8</encoding>
+              <consoleOutput>true</consoleOutput>
+              <failsOnError>true</failsOnError>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <excludes>**/org/apache/cassandra/**,**/org/apache/hadoop/**</excludes>
+            </configuration>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>6.19</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <!-- Create the config file for artifact which can be used to deploy the artifact.
+               Sets the parents field to system:cdap-etl-batch and system:cdap-etl-realtime with whatever
+               version range is set in the etl.versionRange property.
+               also sets a widget and doc property for each file contained in the widgets and docs directories. -->
+          <execution>
+            <id>create-artifact-config</id>
+            <phase>prepare-package</phase>
+            <configuration>
+              <target>
+                <script language="javascript"> <![CDATA[
+                  // for some reason, project.basedir evaluates to null if we just get the property here.
+                  // so we set main.basedir to project.basedir in the pom properties, then main.basedir is used here
+                  // where it evaluates correctly for whatever reason
+                  var baseDir = project.getProperty("main.basedir");
+                  var targetDir = project.getProperty("project.build.directory");
+                  var artifactId = project.getProperty("project.artifactId");
+                  var version = project.getProperty("project.version");
+                  var cfgFile = new java.io.File(targetDir, artifactId + "-" + version + ".json");
+                  if (!cfgFile.exists()) {
+                    cfgFile.createNewFile();
+                  }
+                  var parents = project.getProperty("app.parents").split(",");
+                  var config = {
+                    "parents": [ ],
+                    "properties": {}
+                  }
+                  for (i = 0; i < parents.length; i+=2) {
+                    // because name1[lo,hi],name2[lo,hi] gets split into "name1[lo", "hi]", "name2[lo", "hi]"
+                    // so we have to combine them again
+                    config.parents.push(parents[i] + "," + parents[i+1]);
+                  }
+                  // look in widgets directory for widget config for each plugin
+                  var widgetsDir = new java.io.File(baseDir, project.getProperty("widgets.dir"));
+                  if (widgetsDir.isDirectory()) {
+                    var widgetsFiles = widgetsDir.listFiles();
+                    for (i = 0; i < widgetsFiles.length; i++) {
+                      var widgetsFile = widgetsFiles[i];
+                      if (widgetsFile.isFile()) {
+                        var propertyName = "widgets." + widgetsFile.getName();
+                        // if the filename ends with .json
+                        if (propertyName.indexOf(".json", propertyName.length - 5) !== -1) {
+                          // strip the .json
+                          propertyName = propertyName.slice(0, -5);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(widgetsFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          var contentsAsJson = JSON.parse(contents);
+                          config.properties[propertyName] = JSON.stringify(contentsAsJson);
+                        }
+                      }
+                    }
+                  }
+                  // look in the docs directory for docs for each plugin
+                  var docsDir = new java.io.File(baseDir, project.getProperty("docs.dir"));
+                  if (docsDir.isDirectory()) {
+                    var docFiles = docsDir.listFiles();
+                    for (i = 0; i < docFiles.length; i++) {
+                      var docFile = docFiles[i];
+                      if (docFile.isFile()) {
+                        var propertyName = "doc." + docFile.getName();
+                        // if the filename ends with .md
+                        if (propertyName.indexOf(".md", propertyName.length - 3) !== -1) {
+                          // strip the extension
+                          propertyName = propertyName.slice(0, -3);
+                          var contents = new java.lang.String(java.nio.file.Files.readAllBytes(docFile.toPath()), java.nio.charset.StandardCharsets.UTF_8);
+                          config.properties[propertyName] = contents + "";
+                        }
+                      }
+                    }
+                  }
+                  var fw = new java.io.BufferedWriter(new java.io.FileWriter(cfgFile.getAbsoluteFile()));
+                  fw.write(JSON.stringify(config, null, 2));
+                  fw.close();
+                ]]></script>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileCopySink.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileCopySink.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.hydrator.plugin.batch.file.s3.S3FileMetadata;
+import co.cask.hydrator.plugin.common.ReferenceBatchSink;
+import co.cask.hydrator.plugin.common.ReferencePluginConfig;
+import com.sun.istack.Nullable;
+import org.apache.hadoop.io.NullWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Abstract template for a FileCopySink. The transform method converts a structured record
+ * to AbstractFileMetadata class.
+ */
+public abstract class AbstractFileCopySink
+  extends ReferenceBatchSink<StructuredRecord, NullWritable, AbstractFileMetadata> {
+  protected final AbstractFileCopySinkConfig config;
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractFileCopySink.class);
+
+  public AbstractFileCopySink(AbstractFileCopySinkConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    config.validate();
+  }
+
+  /**
+   * Converts input StructuredRecord to AbstractFileMetadata class. Loads credentials and
+   * file metadata from the input.
+   * @param input The input structured record that contains credentials and file metadata.
+   * @param emitter
+   * @throws Exception
+   */
+  @Override
+  public void transform(StructuredRecord input,
+                        Emitter<KeyValue<NullWritable, AbstractFileMetadata>> emitter)
+    throws Exception {
+    AbstractFileMetadata output;
+    String fsScheme = URI.create((String) input.get(AbstractFileMetadata.HOST_URI)).getScheme();
+    switch (fsScheme) {
+      case "s3n" :
+      case "s3a" :
+        output = new S3FileMetadata(input);
+        break;
+
+      default:
+        throw new IllegalArgumentException(fsScheme + "is not supported.");
+
+    }
+    emitter.emit(new KeyValue<NullWritable, AbstractFileMetadata>(null, output));
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+    config.validate();
+    context.addOutput(Output.of(config.referenceName, new FileCopyOutputFormatProvider(config)));
+  }
+
+  /**
+   * Abstract class for the configuration of FileCopySink
+   */
+  public abstract class AbstractFileCopySinkConfig extends ReferencePluginConfig {
+    @Macro
+    @Description("The destination path. Will be created if it doesn't exist.")
+    public String basePath;
+
+    @Description("Whether or not to overwrite if the file already exists.")
+    public Boolean enableOverwrite;
+
+    @Description("Whether or not to preserve the owner of the file from source filesystem.")
+    public Boolean preserveFileOwner;
+
+    // TODO: figure out why this still shows up as required in configuration UI
+    @Macro
+    @Nullable
+    @Description("The size of the buffer (in MB) that temporarily stores data from file input stream. Defaults to" +
+      " 1 MB")
+    public Integer bufferSize;
+
+    public AbstractFileCopySinkConfig(String name, String basePath, Boolean enableOverwrite,
+                                      Boolean preserveFileOwner, @Nullable Integer bufferSize) {
+      super(name);
+      this.basePath = basePath;
+      this.enableOverwrite = enableOverwrite;
+      this.preserveFileOwner = preserveFileOwner;
+      this.bufferSize = bufferSize;
+    }
+
+    public void validate() {
+      if (!this.containsMacro("bufferSize")) {
+        if (bufferSize <= 0) {
+          throw new IllegalArgumentException("Buffer size must be a positive integer.");
+        }
+      }
+    }
+
+    /*
+     * Additional configurations for the file sink should be implemented in the extended class
+     */
+
+    public abstract String getScheme();
+
+    public abstract String getHostUri();
+  }
+
+  /**
+   * Adds necessary configuration resources and provides OutputFormat Class
+   */
+  public class FileCopyOutputFormatProvider implements OutputFormatProvider {
+    private final Map<String, String> conf;
+
+    public FileCopyOutputFormatProvider(AbstractFileCopySink.AbstractFileCopySinkConfig config) {
+      this.conf = new HashMap<>();
+      FileCopyOutputFormat.setBasePath(conf, config.basePath);
+      FileCopyOutputFormat.setEnableOverwrite(conf, config.enableOverwrite.toString());
+      FileCopyOutputFormat.setPreserveFileOwner(conf, config.preserveFileOwner.toString());
+      FileCopyOutputFormat.setFilesystemScheme(conf, config.getScheme());
+
+      if (config.bufferSize != null) {
+        // bufferSize is in megabytes
+        FileCopyOutputFormat.setBufferSize(conf, String.valueOf(config.bufferSize << 20));
+      } else {
+        FileCopyOutputFormat.setBufferSize(conf, String.valueOf(FileCopyRecordWriter.DEFAULT_BUFFER_SIZE));
+      }
+
+      // set the URI for the destination filesystem if it's provided
+      if (config.getHostUri() != null) {
+        FileCopyOutputFormat.setFilesystemHostUri(conf, config.getHostUri());
+      }
+    }
+
+    @Override
+    public Map<String, String> getOutputFormatConfiguration() {
+      return conf;
+    }
+
+    @Override
+    public String getOutputFormatClassName() {
+      return FileCopyOutputFormat.class.getName();
+    }
+  }
+
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadata.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadata.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract class that contains file metadata fields.
+ * Extend from this class to add credentials specific to different filesystems.
+ */
+public abstract class AbstractFileMetadata implements Comparable {
+
+  public static final String FILE_NAME = "fileName";
+  public static final String FILE_SIZE = "fileSize";
+  public static final String MODIFICATION_TIME = "modificationTime";
+  public static final String OWNER = "owner";
+  public static final String GROUP = "group";
+  public static final String FULL_PATH = "fullPath";
+  public static final String IS_FOLDER = "isFolder";
+  public static final String RELATIVE_PATH = "relativePath";
+  public static final String PERMISSION = "permission";
+  public static final String HOST_URI = "hostURI";
+
+  public static final Schema DEFAULT_SCHEMA = Schema.recordOf(
+    "metadata",
+    Schema.Field.of(FILE_NAME, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(FULL_PATH, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(FILE_SIZE, Schema.of(Schema.Type.LONG)),
+    Schema.Field.of(MODIFICATION_TIME, Schema.of(Schema.Type.LONG)),
+    Schema.Field.of(GROUP, Schema.of(Schema.Type.LONG)),
+    Schema.Field.of(OWNER, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(IS_FOLDER, Schema.of(Schema.Type.BOOLEAN)),
+    Schema.Field.of(RELATIVE_PATH, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(PERMISSION, Schema.of(Schema.Type.INT)),
+    Schema.Field.of(HOST_URI, Schema.of(Schema.Type.STRING))
+  );
+
+
+  // contains only the name of the file
+  private final String fileName;
+
+  // full path of the file in the source filesystem
+  private final String fullPath;
+
+  // file size
+  private final long fileSize;
+
+  // modification time of file
+  private final long modificationTime;
+
+  // file owner's group
+  private final String group;
+
+  // file owner
+  private final String owner;
+
+  // whether or not the file is a folder
+  private final boolean isFolder;
+
+  /*
+   * The relavite path is constructed by deleting the portion of the source
+   * path that comes before the last path separator ("/") from the full path.
+   * It is assumed here that the source path is always a prefix of the full
+   * path.
+   *
+   * For example, given full path http://example.com/foo/bar/baz/index.html
+   *              and source path /foo/bar
+   *              the relative path will be bar/baz/index.html
+   */
+  private final String relativePath;
+
+  // file permission, encoded in short
+  private final short permission;
+
+  /*
+   * URI for the Filesystem
+   * For instance, the hostURI for http://abc.def.ghi/new/index.html is http://abc.def.ghi
+   */
+  private final String hostURI;
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractFileMetadata.class);
+
+  protected AbstractFileMetadata(FileStatus fileStatus, String sourcePath) throws IOException {
+    fileName = fileStatus.getPath().getName();
+    fullPath = fileStatus.getPath().toUri().getPath();
+    isFolder = fileStatus.isDirectory();
+    modificationTime = fileStatus.getModificationTime();
+    owner = fileStatus.getOwner();
+    group = fileStatus.getGroup();
+    fileSize = fileStatus.getLen();
+    permission = fileStatus.getPermission().toShort();
+
+    // check if sourcePath is a valid prefix of fullPath
+    if (fullPath.startsWith(sourcePath)) {
+      relativePath = fullPath.substring(sourcePath.lastIndexOf(Path.SEPARATOR) + 1);
+    } else {
+      throw new IOException("sourcePath should be a valid prefix of fullPath");
+    }
+
+    // construct host URI given the full path from filestatus
+    try {
+      hostURI = new URI(fileStatus.getPath().toUri().getScheme(), fileStatus.getPath().toUri().getHost(), null, null)
+        .toString();
+    } catch (URISyntaxException e) {
+      throw new IOException(e.getMessage());
+    }
+  }
+
+  protected AbstractFileMetadata(StructuredRecord record) {
+    this.fileName = record.get(FILE_NAME);
+    this.fullPath = record.get(FULL_PATH);
+    this.modificationTime = record.get(MODIFICATION_TIME);
+    this.group = record.get(GROUP);
+    this.owner = record.get(OWNER);
+    this.fileSize = record.get(FILE_SIZE);
+    this.isFolder = record.get(IS_FOLDER);
+    this.relativePath = record.get(RELATIVE_PATH);
+    this.permission = record.get(PERMISSION);
+    this.hostURI = record.get(HOST_URI);
+  }
+
+  /**
+   * use this constructor to deserialize from DataInput
+   * @param dataInput
+   */
+  protected AbstractFileMetadata(DataInput dataInput) throws IOException {
+    this.fileName = dataInput.readUTF();
+    this.fullPath = dataInput.readUTF();
+    this.modificationTime = dataInput.readLong();
+    this.group = dataInput.readUTF();
+    this.owner = dataInput.readUTF();
+    this.fileSize = dataInput.readLong();
+    this.isFolder = dataInput.readBoolean();
+    this.relativePath = dataInput.readUTF();
+    this.permission = dataInput.readShort();
+    this.hostURI = dataInput.readUTF();
+  }
+
+  public String getFullPath() {
+    return fullPath;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public long getFileSize() {
+    return fileSize;
+  }
+
+  public long getModificationTime() {
+    return modificationTime;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public boolean isFolder() {
+    return isFolder;
+  }
+
+  public String getRelativePath() {
+    return relativePath;
+  }
+
+  public short getPermission() {
+    return permission;
+  }
+
+  public String getHostURI() {
+    return hostURI;
+  }
+
+  /**
+   * Converts to StructuredRecord
+   */
+  public StructuredRecord toRecord() {
+
+    // initialize output schema
+    Schema outputSchema;
+    List<Schema.Field> fieldList = new ArrayList<>(DEFAULT_SCHEMA.getFields());
+    fieldList.addAll(getCredentialSchema().getFields());
+    outputSchema = Schema.recordOf("metadata", fieldList);
+
+    StructuredRecord.Builder outputBuilder = StructuredRecord.builder(outputSchema)
+      .set(FILE_NAME, fileName)
+      .set(FULL_PATH, fullPath)
+      .set(FILE_SIZE, fileSize)
+      .set(MODIFICATION_TIME, modificationTime)
+      .set(GROUP, group)
+      .set(OWNER, owner)
+      .set(IS_FOLDER, isFolder)
+      .set(RELATIVE_PATH, relativePath)
+      .set(PERMISSION, permission)
+      .set(HOST_URI, hostURI);
+    addCredentialsToBuilder(outputBuilder);
+
+    return outputBuilder.build();
+  }
+
+  @Override
+  public int compareTo(Object o) {
+    return Long.compare(fileSize, ((AbstractFileMetadata) o).getFileSize());
+  }
+
+  public void write(DataOutput dataOutput) throws IOException {
+    dataOutput.writeUTF(getFileName());
+    dataOutput.writeUTF(getFullPath());
+    dataOutput.writeLong(getModificationTime());
+    dataOutput.writeUTF(getGroup());
+    dataOutput.writeUTF(getOwner());
+    dataOutput.writeLong(getFileSize());
+    dataOutput.writeBoolean(isFolder());
+    dataOutput.writeUTF(getRelativePath());
+    dataOutput.writeShort(getPermission());
+    dataOutput.writeUTF(getHostURI());
+  }
+
+  /**
+   * @return Credential schema for different filesystems
+   */
+  protected abstract Schema getCredentialSchema();
+
+  protected abstract void addCredentialsToBuilder(StructuredRecord.Builder builder);
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataSource.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataSource.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.hydrator.plugin.common.ReferenceBatchSource;
+import co.cask.hydrator.plugin.common.ReferencePluginConfig;
+import org.apache.hadoop.io.NullWritable;
+
+/**
+ * Abstract class for FileCopySource plugin. Extracts metadata of desired files
+ * from the source database.
+ * @param <K> the FileMetadata class specific to each database.
+ */
+public abstract class AbstractFileMetadataSource<K extends AbstractFileMetadata>
+  extends ReferenceBatchSource<NullWritable, K, StructuredRecord> {
+
+  private final AbstractFileMetadataSourceConfig config;
+
+  public AbstractFileMetadataSource(AbstractFileMetadataSourceConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  /**
+   * Loads configurations from UI and check if they are valid.
+   */
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    this.config.validate();
+  }
+
+  /**
+   * Initialize the output StructuredRecord Schema here.
+   * @param context
+   * @throws Exception
+   */
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+  }
+
+  /**
+   * Load job configurations here.
+   */
+  public void prepareRun(BatchSourceContext context) throws Exception {
+    config.validate();
+  }
+
+  /**
+   * Convert file metadata to StructuredRecord and emit.
+   */
+  public abstract void transform(KeyValue<NullWritable, K> input, Emitter<StructuredRecord> emitter);
+
+  /**
+   * Abstract class for the configuration of FileCopySink
+   */
+  public abstract class AbstractFileMetadataSourceConfig extends ReferencePluginConfig {
+
+    @Macro
+    @Description("Collection of sourcePaths separated by \",\" to read files from")
+    public String sourcePaths;
+
+    @Macro
+    @Description("The number of files each split reads in")
+    public Integer maxSplitSize;
+
+    @Macro
+    @Description("The URI of the filesystem")
+    public String filesystemURI;
+
+    @Description("Whether or not to copy recursively")
+    public Boolean recursiveCopy;
+
+    public AbstractFileMetadataSourceConfig(String name, String sourcePaths,
+                                            Integer maxSplitSize, String filesystemURI) {
+      super(name);
+      this.sourcePaths = sourcePaths;
+      this.maxSplitSize = maxSplitSize;
+      this.filesystemURI = filesystemURI;
+    }
+
+    public void validate() {
+      if (!this.containsMacro("maxSplitSize")) {
+        if (maxSplitSize <= 0) {
+          throw new IllegalArgumentException("Max split size must be a positive integer.");
+        }
+      }
+    }
+  }
+
+    /*
+     * Put additional configurations here for specific databases.
+     */
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputFormat.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputFormat.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.PriorityQueue;
+
+
+/**
+ * Abstract class that implements the inputFormat for the FileCopySource plugin to
+ * read file metadata. The getsplit method creates splits according to user-set configuration
+ * and tries to assign files to each split such that every split copies roughly the same number of bytes.
+ * @param <KEY>
+ * @param <VALUE>
+ */
+public abstract class AbstractMetadataInputFormat<KEY, VALUE> extends InputFormat<KEY, VALUE> {
+
+  protected static final String SOURCE_PATHS = "source.paths";
+  protected static final String MAX_SPLIT_SIZE = "max.split.size";
+  protected static final String FS_URI = "filesystem.uri";
+  protected static final String RECURSIVE_COPY = "recursive.copy";
+  protected static final int DEFAULT_MAX_SPLIT_SIZE = 128;
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractMetadataInputFormat.class);
+
+  public AbstractMetadataInputFormat() {
+  }
+
+  @Override
+  public List<InputSplit> getSplits(JobContext jobContext) throws IOException, InterruptedException {
+    // connect to the source filesystem
+    Configuration conf = jobContext.getConfiguration();
+    URI uri = URI.create(conf.get(FS_URI));
+    String[] sourcePaths = conf.get(SOURCE_PATHS).split(",");
+    boolean recursive = conf.getBoolean(RECURSIVE_COPY, true);
+    FileSystem fileSystem = FileSystem.get(uri, conf);
+    int maxSplitSize = conf.getInt(MAX_SPLIT_SIZE, DEFAULT_MAX_SPLIT_SIZE);
+
+    // scan the directories specified by the user
+    List<AbstractFileMetadata> fileMetaDataList = new ArrayList<>();
+    for (String prefix : sourcePaths) {
+      recursivelyAddFileStatus(fileMetaDataList, prefix, new Path(prefix), recursive, fileSystem, conf);
+    }
+
+    // sort fileMetadataList in descending order such that total number of bytes can be more evenly distributed
+    Collections.sort(fileMetaDataList);
+    Collections.reverse(fileMetaDataList);
+
+    // compute number of splits and instantiate the splits
+    // We use a priority queue to keep track of the smallest split (fewest bytes assigned to it)
+    int numSplits = (fileMetaDataList.size() - 1) / maxSplitSize + 1;
+    PriorityQueue<AbstractMetadataInputSplit> abstractInputSplits = new PriorityQueue<>(numSplits);
+    for (int i = 0; i < numSplits; i++) {
+      abstractInputSplits.add(getInputSplit());
+    }
+
+    // assign each split approximately the same number of bytes (2-approx)
+    List<InputSplit> inputSplits = new ArrayList<>();
+    for (AbstractFileMetadata fileMetadata : fileMetaDataList) {
+      // remove the smallest split from the priority queue and add a new file to it
+      AbstractMetadataInputSplit minInputSplit = abstractInputSplits.poll();
+      minInputSplit.addFileMetadata(fileMetadata);
+
+      // if the inputsplit has number files more than maxSplitSize, we stop adding files to it
+      // otherwise we put it back into the priority queue
+      if (minInputSplit.getLength() < maxSplitSize) {
+        abstractInputSplits.add(minInputSplit);
+      } else {
+        inputSplits.add(minInputSplit);
+      }
+    }
+
+    // add the rest of the splits still on the PriorityQueue into the return list
+    inputSplits.addAll(abstractInputSplits);
+
+    return inputSplits;
+  }
+
+
+  @Override
+  public RecordReader createRecordReader(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
+    throws IOException, InterruptedException {
+    MetadataRecordReader recordReader = new MetadataRecordReader();
+    recordReader.initialize(inputSplit, taskAttemptContext);
+    return recordReader;
+  }
+
+  /**
+   * Because the existing Filesystem.listFiles(Path, Boolean) doesn't list empty directories, we
+   * added our own method to recursively traverse the file directories. If the path doesn't exist
+   * in the source filesystem, it logs a warning and skips the path.
+   * @param fileMetadataList The list that contains all the files under fileStatus.getPath
+   * @param prefix The user-set path that was used to get this group of files
+   * @param path The path of the file that will be inserted into fileMetadataList.
+   * @param recursive Whether or not to recursively scan the directories.
+   * @param filesystem The filesystem that contains the files.
+   * @param conf The configuration that contains credential information needed to connect to the filesystem.
+   * @throws IOException
+   */
+  private void recursivelyAddFileStatus(List<AbstractFileMetadata> fileMetadataList,
+                                         String prefix, Path path, Boolean recursive,
+                                         FileSystem filesystem, Configuration conf) throws IOException {
+    try {
+      RemoteIterator<LocatedFileStatus> iter = filesystem.listLocatedStatus(path);
+      while (iter.hasNext()) {
+        LocatedFileStatus fileStatus = iter.next();
+        fileMetadataList.add(getFileMetadata(fileStatus, prefix, conf));
+        if (fileStatus.isDirectory() && recursive) {
+          recursivelyAddFileStatus(fileMetadataList, prefix, fileStatus.getPath(), recursive, filesystem, conf);
+        }
+      }
+    } catch (FileNotFoundException e) {
+      // log a warning and skip if the path doesn't exist
+      LOG.warn(e.getMessage());
+    }
+  }
+
+  protected abstract AbstractMetadataInputSplit getInputSplit();
+
+  protected abstract AbstractFileMetadata getFileMetadata(FileStatus fileStatus, String sourcePath, Configuration conf)
+    throws IOException;
+
+  public static void setSourcePaths(Configuration conf, String value) {
+    conf.set(SOURCE_PATHS, value);
+  }
+
+  public static void setMaxSplitSize(Configuration conf, int value) {
+    conf.setInt(MAX_SPLIT_SIZE, value);
+  }
+
+  public static void setURI(Configuration conf, String value) {
+    conf.set(FS_URI, value);
+  }
+
+  public static void setRecursiveCopy(Configuration conf, String value) {
+    conf.set(RECURSIVE_COPY, value);
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplit.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplit.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract class that implements information for InputSplit.
+ * Contains a list of fileMetadata that is assigned to the specific split.
+ */
+public abstract class AbstractMetadataInputSplit extends InputSplit implements Writable, Comparable {
+  private List<AbstractFileMetadata> fileMetaDataList;
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractMetadataInputSplit.class);
+  private long totalBytes;
+
+  public AbstractMetadataInputSplit(List<AbstractFileMetadata> fileMetaDataList) {
+    this.fileMetaDataList = fileMetaDataList;
+    this.totalBytes = 0;
+    for (AbstractFileMetadata fileMetaData : fileMetaDataList) {
+      this.totalBytes += fileMetaData.getFileSize();
+    }
+  }
+
+  public AbstractMetadataInputSplit() {
+    this.fileMetaDataList = new ArrayList<>();
+    this.totalBytes = 0;
+  }
+
+  public List<AbstractFileMetadata> getFileMetaDataList() {
+    return this.fileMetaDataList;
+  }
+
+  @Override
+  public void write(DataOutput dataOutput) throws IOException {
+    try {
+      // write total number of file bytes
+      dataOutput.writeLong(this.getTotalBytes());
+
+      // write number of files
+      dataOutput.writeLong(this.getLength());
+
+      for (AbstractFileMetadata fileMetaData : fileMetaDataList) {
+        // convert each filestatus (serializable) to byte array
+        fileMetaData.write(dataOutput);
+      }
+
+    } catch (InterruptedException interruptedException) {
+      throw new IOException("Failed to get length for InputSplit");
+    }
+  }
+
+  @Override
+  public void readFields(DataInput dataInput) throws IOException {
+    // get total number of bytes
+    totalBytes = dataInput.readLong();
+
+    // read number of files
+    long numObjects = dataInput.readLong();
+
+    fileMetaDataList = new ArrayList<>();
+    for (long i = 0; i < numObjects; i++) {
+      AbstractFileMetadata metadata = readFileMetaData(dataInput);
+      fileMetaDataList.add(metadata);
+    }
+  }
+
+  /**
+   * @return the number of files in this split
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  @Override
+  public long getLength() throws IOException, InterruptedException {
+    return fileMetaDataList.size();
+  }
+
+  /**
+   * @return the total number of file bytes in this split
+   */
+  public long getTotalBytes() {
+    return this.totalBytes;
+  }
+
+  @Override
+  public String[] getLocations() throws IOException, InterruptedException {
+    return new String[0];
+  }
+
+  public void addFileMetadata(AbstractFileMetadata fileMetaData) {
+    fileMetaDataList.add(fileMetaData);
+    totalBytes += fileMetaData.getFileSize();
+  }
+
+  @Override
+  /**
+   * Compares the total number of bytes contained in the split
+   */
+  public int compareTo(Object o) {
+    return Long.compare(getTotalBytes(), ((AbstractMetadataInputSplit) o).getTotalBytes());
+  }
+
+  protected abstract AbstractFileMetadata readFileMetaData(DataInput dataInput) throws IOException;
+}
+
+

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Class for the OutputFormat that FileCopySink uses.
+ */
+public class FileCopyOutputFormat extends OutputFormat {
+  public static final String BASE_PATH = "base.path";
+  public static final String ENABLE_OVERWRITE = "enable.overwrite";
+  public static final String PRESERVE_OWNER = "preserve.owner";
+  public static final String BUFFER_SIZE = "buffer.size";
+  public static final String FS_HOST_URI = "filesystem.host.uri";
+  public static final String FS_SCHEME = "filesystem.scheme";
+
+  private static final Logger LOG = LoggerFactory.getLogger(FileCopyOutputFormat.class);
+
+  public static void setBasePath(Map<String, String> conf, String value) {
+    conf.put(BASE_PATH, value);
+  }
+
+  public static void setEnableOverwrite(Map<String, String> conf, String value) {
+    conf.put(ENABLE_OVERWRITE, value);
+  }
+
+  public static void setPreserveFileOwner(Map<String, String> conf, String value) {
+    conf.put(PRESERVE_OWNER, value);
+  }
+
+  public static void setBufferSize(Map<String, String> conf, String value) {
+    conf.put(BUFFER_SIZE, value);
+  }
+
+  public static void setFilesystemHostUri(Map<String, String> conf, String value) {
+    conf.put(FS_HOST_URI, value);
+  }
+
+  public static void setFilesystemScheme(Map<String, String> conf, String value) {
+    conf.put(FS_SCHEME, value);
+  }
+
+  @Override
+  public void checkOutputSpecs(JobContext jobContext) throws IOException, InterruptedException {
+    // check if base path is set
+    if (jobContext.getConfiguration().get(BASE_PATH, null) == null) {
+      throw new IOException("Base path not set.");
+    }
+  }
+
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext taskAttemptContext) {
+    // TODO: implement an OutputCommitter for file copying jobs, or investigate whether we can use FileOutputCommitter
+    return new OutputCommitter() {
+      @Override
+      public void setupJob(JobContext jobContext) throws IOException {
+        // no op
+      }
+
+      @Override
+      public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+        // no op
+      }
+
+      @Override
+      public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+        return false;
+      }
+
+      @Override
+      public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+        // no op
+      }
+
+      @Override
+      public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+        // no op
+      }
+    };
+  }
+
+  @Override
+  public RecordWriter getRecordWriter(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+    Configuration conf = taskAttemptContext.getConfiguration();
+    return new FileCopyRecordWriter(conf);
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyRecordWriter.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyRecordWriter.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import co.cask.hydrator.plugin.batch.file.s3.S3FileMetadata;
+import co.cask.hydrator.plugin.batch.file.s3.S3MetadataInputFormat;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * The record writer that takes file metadata and streams data from source database
+ * to destination database
+ */
+public class FileCopyRecordWriter extends RecordWriter<NullWritable, AbstractFileMetadata> {
+  private final FileSystem destFileSystem;
+  private final String basePath;
+  private final boolean enableOverwrite;
+  private final boolean preserveOwner;
+  private final int bufferSize;
+
+  // buffer size defaults to 1 MB
+  public static final int DEFAULT_BUFFER_SIZE = 1 << 20;
+  private static final Logger LOG = LoggerFactory.getLogger(FileCopyRecordWriter.class);
+
+  // a Key-Value map from host uri to Filesystem object
+  private Map<String, FileSystem> sourceFilesystemMap;
+
+  public FileCopyRecordWriter(Configuration conf) throws IOException {
+    // always disable caching when obtaining destination filesystem
+    conf.set(String.format("fs.%s.impl.disable.cache", conf.get(FileCopyOutputFormat.FS_SCHEME)), String.valueOf(true));
+
+    // connect to destination filesystem with uri if it is provided
+    String uriString = conf.get(FileCopyOutputFormat.FS_HOST_URI, null);
+    if (uriString != null) {
+      destFileSystem = FileSystem.get(URI.create(uriString), conf);
+    } else {
+      destFileSystem = FileSystem.get(conf);
+    }
+
+    // initialize other properties for writing to destination filesystem
+    basePath = conf.get(FileCopyOutputFormat.BASE_PATH);
+    enableOverwrite = conf.getBoolean(FileCopyOutputFormat.ENABLE_OVERWRITE, false);
+    preserveOwner = conf.getBoolean(FileCopyOutputFormat.PRESERVE_OWNER, false);
+    bufferSize = conf.getInt(FileCopyOutputFormat.BUFFER_SIZE, DEFAULT_BUFFER_SIZE);
+    sourceFilesystemMap = new HashMap<>();
+  }
+
+  @Override
+  public void write(NullWritable key, AbstractFileMetadata fileMetadata) throws IOException, InterruptedException {
+
+    if (fileMetadata.getRelativePath().isEmpty()) {
+      // nothing to create
+      return;
+    }
+
+    // construct file paths for source and destination
+    Path srcPath = new Path(fileMetadata.getFullPath());
+    Path destPath = new Path(basePath, fileMetadata.getRelativePath());
+    FsPermission permission = new FsPermission(fileMetadata.getPermission());
+
+    // immediately return if we don't want to overwrite and file exists in destination
+    if (!enableOverwrite && destFileSystem.exists(destPath)) {
+      return;
+    }
+
+    // get source database connection
+    String uriString = fileMetadata.getHostURI();
+    if (!sourceFilesystemMap.containsKey(uriString)) {
+      sourceFilesystemMap.put(uriString, getSourceFilesystemConnection(fileMetadata));
+    }
+    FileSystem sourceFilesystem = sourceFilesystemMap.get(uriString);
+
+    // do some checks to see if we need to copy the file
+    if (fileMetadata.isFolder()) {
+      // create an empty folder and return
+      if (!destFileSystem.exists(destPath) && sourceFilesystem.isDirectory(srcPath)) {
+        destFileSystem.mkdirs(destPath, permission);
+        if (preserveOwner) {
+          destFileSystem.setOwner(destPath, fileMetadata.getOwner(), fileMetadata.getGroup());
+        }
+      }
+      return;
+    } else if (!sourceFilesystem.exists(srcPath)) {
+      // file doesn't exist in source, return immediately
+      LOG.warn("{} doesn't exist in source filesystem.", fileMetadata.getFullPath());
+      return;
+    }
+
+    // data streaming
+    FSDataInputStream inputStream = sourceFilesystem.open(srcPath, bufferSize);
+    FSDataOutputStream outputStream = FileSystem.create(destFileSystem, destPath, permission);
+    try {
+      byte[] buf = new byte[bufferSize];
+      int len;
+      while ((len = inputStream.read(buf)) >= 0) {
+        outputStream.write(buf, 0, len);
+      }
+    } finally {
+      // we have to do this to make sure even if one stream fails to close, it
+      // still attempts to close the other stream
+      try {
+        inputStream.close();
+      } finally {
+        outputStream.close();
+        // the owner is set only if the output stream is sucessfully closed
+        if (preserveOwner) {
+          destFileSystem.setOwner(destPath, fileMetadata.getOwner(), fileMetadata.getGroup());
+        }
+      }
+    }
+  }
+
+  @Override
+  public void close(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+    // attempts to close the other even if one fails
+    try {
+      destFileSystem.close();
+    } finally {
+      safelyCloseSourceFilesystems(sourceFilesystemMap.values().iterator());
+    }
+  }
+
+  /**
+   * this method attempts to close every Filesystem object in the list, logs a warning
+   * for each object that fails to close
+   * @param fs The iterator over all the Filesystems we wish to close.
+   */
+  private void safelyCloseSourceFilesystems(Iterator<FileSystem> fs) {
+    while (fs.hasNext()) {
+      try {
+        fs.next().close();
+      } catch (IOException e) {
+        LOG.warn(e.getMessage());
+      }
+    }
+  }
+
+  private FileSystem getSourceFilesystemConnection(AbstractFileMetadata metadata)
+    throws IOException {
+    Configuration conf = new Configuration(false);
+    conf.clear();
+
+    // always disable caching for source Filesystem objects
+    URI uri = URI.create(metadata.getHostURI());
+    String disableCacheName = String.format("fs.%s.impl.disable.cache", uri.getScheme());
+    conf.set(disableCacheName, String.valueOf(true));
+
+    switch (uri.getScheme()) {
+      case "s3a":
+        S3FileMetadata s3aFileMetadata = (S3FileMetadata) metadata;
+        S3MetadataInputFormat.setS3aAccessKeyId(conf, s3aFileMetadata.getAccessKeyId());
+        S3MetadataInputFormat.setS3aSecretKeyId(conf, s3aFileMetadata.getSecretKeyId());
+        S3MetadataInputFormat.setS3aFsClass(conf);
+        break;
+      case "s3n":
+        S3FileMetadata s3nFileMetadata = (S3FileMetadata) metadata;
+        S3MetadataInputFormat.setS3nAccessKeyId(conf, s3nFileMetadata.getAccessKeyId());
+        S3MetadataInputFormat.setS3nSecretKeyId(conf, s3nFileMetadata.getSecretKeyId());
+        S3MetadataInputFormat.setS3nFsClass(conf);
+        break;
+      default:
+        throw new IOException(uri.getScheme() + " is not supported.");
+    }
+
+    return FileSystem.get(uri, conf);
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/MetadataRecordReader.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/MetadataRecordReader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * Returns key that contains file path.
+ * Returns value that contains file attributes.
+ */
+public class MetadataRecordReader extends RecordReader<NullWritable, AbstractFileMetadata> {
+
+  protected int currentIndex;
+  protected AbstractMetadataInputSplit split;
+
+  public MetadataRecordReader() {
+    super();
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException, InterruptedException {
+    if ((currentIndex + 1) < split.getLength()) {
+      currentIndex++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public NullWritable getCurrentKey() throws IOException, InterruptedException {
+    return null;
+  }
+
+
+  @Override
+  public float getProgress() throws IOException, InterruptedException {
+    return (1 - ((float) currentIndex / split.getLength()));
+  }
+
+  @Override
+  public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
+    throws IOException, InterruptedException {
+
+    // sorry I should think of a better way instead of casting
+    this.split = (AbstractMetadataInputSplit) inputSplit;
+
+    this.currentIndex = -1;
+  }
+
+  @Override
+  public AbstractFileMetadata getCurrentValue() throws IOException, InterruptedException {
+    return split.getFileMetaDataList().get(currentIndex);
+  }
+
+  @Override
+  public void close() throws IOException {
+
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/hdfs/HDFSFileCopySink.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/hdfs/HDFSFileCopySink.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file.hdfs;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.hydrator.plugin.batch.file.AbstractFileCopySink;
+import com.sun.istack.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FileCopySink that writes to HDFS.
+ */
+@Plugin(type = BatchSink.PLUGIN_TYPE)
+@Name("HDFSFileCopySink")
+@Description("Copies files from remote filesystem to HDFS")
+public class HDFSFileCopySink extends AbstractFileCopySink {
+
+  private HDFSFileCopySinkConfig config;
+  private static final Logger LOG = LoggerFactory.getLogger(HDFSFileCopySink.class);
+
+  public HDFSFileCopySink(HDFSFileCopySinkConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  /**
+   * Configurations required for connecting to HDFS.
+   */
+  public class HDFSFileCopySinkConfig extends AbstractFileCopySinkConfig {
+    public HDFSFileCopySinkConfig(String name, String basePath, Boolean enableOverwrite,
+                                  Boolean preserveFileOwner, @Nullable Integer bufferSize) {
+      super(name, basePath, enableOverwrite, preserveFileOwner, bufferSize);
+    }
+
+    @Override
+    public String getScheme() {
+      return "hdfs";
+    }
+
+    @Override
+    public String getHostUri() {
+      return null;
+    }
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadata.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadata.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file.s3;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.hydrator.plugin.batch.file.AbstractFileMetadata;
+import org.apache.hadoop.fs.FileStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * Filemetadata specific for S3. Defines credentials that are required for
+ * connecting to S3.
+ */
+public class S3FileMetadata extends AbstractFileMetadata {
+
+  public static final String ACCESS_KEY_ID = "accessKeyID";
+  public static final String SECRET_KEY_ID = "secretKeyID";
+  public static final String REGION = "region";
+  public static final Schema CREDENTIAL_SCHEMA = Schema.recordOf(
+    "metadata",
+    Schema.Field.of(ACCESS_KEY_ID, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(SECRET_KEY_ID, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(REGION, Schema.of(Schema.Type.STRING))
+  );
+
+  private final String accessKeyId;
+  private final String secretKeyId;
+  private final String region;
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3FileMetadata.class);
+
+  public S3FileMetadata(FileStatus fileStatus, String sourcePath,
+                        String accessKeyId, String secretKeyId, String region) throws IOException {
+    super(fileStatus, sourcePath);
+    this.accessKeyId = accessKeyId;
+    this.secretKeyId = secretKeyId;
+    this.region = region;
+  }
+
+  public S3FileMetadata(StructuredRecord record) {
+    super(record);
+    this.accessKeyId = record.get(ACCESS_KEY_ID);
+    this.secretKeyId = record.get(SECRET_KEY_ID);
+    this.region = record.get(REGION);
+  }
+
+  public S3FileMetadata(DataInput input) throws IOException {
+    super(input);
+    this.accessKeyId = input.readUTF();
+    this.secretKeyId = input.readUTF();
+    this.region = input.readUTF();
+  }
+
+  public String getAccessKeyId() {
+    return accessKeyId;
+  }
+
+  public String getSecretKeyId() {
+    return secretKeyId;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  @Override
+  protected Schema getCredentialSchema() {
+    return CREDENTIAL_SCHEMA;
+  }
+
+  @Override
+  protected void addCredentialsToBuilder(StructuredRecord.Builder builder) {
+    builder
+      .set(ACCESS_KEY_ID, accessKeyId)
+      .set(SECRET_KEY_ID, secretKeyId)
+      .set(REGION, region);
+  }
+
+  @Override
+  public void write(DataOutput dataOutput) throws IOException {
+    super.write(dataOutput);
+    dataOutput.writeUTF(accessKeyId);
+    dataOutput.writeUTF(secretKeyId);
+    dataOutput.writeUTF(region);
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadataSource.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadataSource.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package co.cask.hydrator.plugin.batch.file.s3;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.hydrator.plugin.batch.file.AbstractFileMetadataSource;
+import co.cask.hydrator.plugin.common.JobUtils;
+import co.cask.hydrator.plugin.common.SourceInputFormatProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import javax.annotation.Nullable;
+
+/**
+ * FileCopySource plugin that pulls filemetadata from S3 Filesystem.
+ */
+@Plugin(type = BatchSource.PLUGIN_TYPE)
+@Name("S3FileMetadataSource")
+@Description("Reads file metadata from S3 bucket.")
+public class S3FileMetadataSource extends AbstractFileMetadataSource<S3FileMetadata> {
+  private S3FileMetadataSourceConfig config;
+  private static final Logger LOG = LoggerFactory.getLogger(S3FileMetadataSource.class);
+
+  public S3FileMetadataSource(S3FileMetadataSourceConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  @Override
+  public void prepareRun(BatchSourceContext context) throws Exception {
+    super.prepareRun(context);
+    Job job = JobUtils.createInstance();
+    Configuration conf = job.getConfiguration();
+
+    S3MetadataInputFormat.setSourcePaths(conf, config.sourcePaths);
+    S3MetadataInputFormat.setMaxSplitSize(conf, config.maxSplitSize);
+    S3MetadataInputFormat.setRecursiveCopy(conf, config.recursiveCopy.toString());
+    S3MetadataInputFormat.setRegion(conf, config.region);
+    S3MetadataInputFormat.setURI(conf, config.filesystemURI);
+
+    String fsScheme = URI.create(config.filesystemURI).getScheme();
+    if (fsScheme.equals("s3a")) {
+      S3MetadataInputFormat.setS3aAccessKeyId(conf, config.accessKeyId);
+      S3MetadataInputFormat.setS3aSecretKeyId(conf, config.secretKeyId);
+      S3MetadataInputFormat.setS3aFsClass(conf);
+    } else if (fsScheme.equals("s3n")) {
+      S3MetadataInputFormat.setS3nAccessKeyId(conf, config.accessKeyId);
+      S3MetadataInputFormat.setS3nSecretKeyId(conf, config.secretKeyId);
+      S3MetadataInputFormat.setS3nFsClass(conf);
+    } else {
+      throw new IllegalArgumentException("Scheme must be either s3a or s3n.");
+    }
+
+    context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(S3MetadataInputFormat.class, conf)));
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+  }
+
+  @Override
+  public void transform(KeyValue<NullWritable, S3FileMetadata> input, Emitter<StructuredRecord> emitter) {
+    emitter.emit(input.getValue().toRecord());
+  }
+
+  /**
+   * AbstractCredentials required for connecting to S3Filesystem.
+   */
+  public class S3FileMetadataSourceConfig extends AbstractFileMetadataSourceConfig {
+
+    // configurations for S3
+    @Macro
+    @Description("Your AWS Access Key Id")
+    public String accessKeyId;
+
+    @Macro
+    @Description("Your AWS Secret Key Id")
+    public String secretKeyId;
+
+    @Macro
+    @Nullable
+    @Description("The AWS Region to operate in")
+    public String region;
+
+    public S3FileMetadataSourceConfig(String name, String sourcePaths, Integer maxSplitSize, String filesystemURI,
+                                      String accessKeyId, String secretKeyId, String region) {
+      super(name, sourcePaths, maxSplitSize, filesystemURI);
+      this.accessKeyId = accessKeyId;
+      this.secretKeyId = secretKeyId;
+      this.region = region;
+    }
+
+    @Override
+    public void validate() {
+      super.validate();
+      if (!this.containsMacro("filesystemURI")) {
+        URI fsUri = URI.create(filesystemURI);
+        if (!fsUri.getScheme().equals("s3a") && !fsUri.getScheme().equals("s3n")) {
+          throw new IllegalArgumentException("URI scheme for S3 source must be s3a or s3n");
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputFormat.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputFormat.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file.s3;
+
+import co.cask.hydrator.plugin.batch.file.AbstractFileMetadata;
+import co.cask.hydrator.plugin.batch.file.AbstractMetadataInputFormat;
+import co.cask.hydrator.plugin.batch.file.AbstractMetadataInputSplit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3native.NativeS3FileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * MetadataInputFormat for S3 Filesystem. Implements credentials setters
+ * specific for S3
+ */
+public class S3MetadataInputFormat extends AbstractMetadataInputFormat {
+
+  // configs for s3a
+  public static final String S3A_ACCESS_KEY_ID = "fs.s3a.access.key";
+  public static final String S3A_SECRET_KEY_ID = "fs.s3a.secret.key";
+  public static final String S3A_FS_CLASS = "fs.s3a.impl";
+
+  // configs for s3n
+  public static final String S3N_ACCESS_KEY_ID = "fs.s3n.awsAccessKeyId";
+  public static final String S3N_SECRET_KEY_ID = "fs.s3n.awsSecretAccessKey";
+  public static final String S3N_FS_CLASS = "fs.s3n.impl";
+
+  public static final String REGION = "amazons3.region";
+  public static final Logger LOG = LoggerFactory.getLogger(S3MetadataInputFormat.class);
+
+
+  public static void setS3aAccessKeyId(Configuration conf, String value) {
+    conf.set(S3A_ACCESS_KEY_ID, value);
+  }
+
+  public static void setS3aSecretKeyId(Configuration conf, String value) {
+    conf.set(S3A_SECRET_KEY_ID, value);
+  }
+
+  public static void setS3aFsClass(Configuration conf) {
+    conf.set(S3A_FS_CLASS, S3AFileSystem.class.getName());
+  }
+
+  public static void setS3nAccessKeyId(Configuration conf, String value) {
+    conf.set(S3N_ACCESS_KEY_ID, value);
+  }
+
+  public static void setS3nSecretKeyId(Configuration conf, String value) {
+    conf.set(S3N_SECRET_KEY_ID, value);
+  }
+
+  public static void setS3nFsClass(Configuration conf) {
+    conf.set(S3N_FS_CLASS, NativeS3FileSystem.class.getName());
+  }
+
+  public static void setRegion(Configuration conf, String value) {
+    conf.set(REGION, value);
+  }
+
+  @Override
+  protected AbstractMetadataInputSplit getInputSplit() {
+    return new S3MetadataInputSplit();
+  }
+
+  @Override
+  protected AbstractFileMetadata getFileMetadata(FileStatus fileStatus, String sourcePath, Configuration conf)
+    throws IOException {
+    switch (fileStatus.getPath().toUri().getScheme()) {
+      case "s3a":
+        return new S3FileMetadata(fileStatus, sourcePath,
+                                  conf.get(S3A_ACCESS_KEY_ID), conf.get(S3A_SECRET_KEY_ID), conf.get(REGION));
+      case "s3n":
+        return new S3FileMetadata(fileStatus, sourcePath,
+                                  conf.get(S3N_ACCESS_KEY_ID), conf.get(S3N_SECRET_KEY_ID), conf.get(REGION));
+      default:
+        throw new IOException("Scheme must be either s3a or s3n.");
+    }
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputSplit.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputSplit.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file.s3;
+
+import co.cask.hydrator.plugin.batch.file.AbstractFileMetadata;
+import co.cask.hydrator.plugin.batch.file.AbstractMetadataInputSplit;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.List;
+
+
+/**
+ * InputSplit that implements methods for serializing S3 AbstractCredentials
+ */
+public class S3MetadataInputSplit extends AbstractMetadataInputSplit {
+  public S3MetadataInputSplit(List<AbstractFileMetadata> s3FileMetadataList) {
+    super(s3FileMetadataList);
+  }
+
+  public S3MetadataInputSplit() {
+    super();
+  }
+
+  @Override
+  protected AbstractFileMetadata readFileMetaData(DataInput dataInput) throws IOException {
+    return new S3FileMetadata(dataInput);
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/common/ConfigurationUtils.java
+++ b/src/main/java/co/cask/hydrator/plugin/common/ConfigurationUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.hydrator.plugin.common;
+
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for providing operations on the {@link Configuration}.
+ */
+public final class ConfigurationUtils {
+  private ConfigurationUtils() {
+    // no-op
+  }
+
+  /**
+   * Get the {@link Map} of properties which are newly added or have updated in the configuration instance passed
+   * to this method as a parameter. The modified configurations are compared with the default configurations
+   * created using {@code new Configuation()}.
+   * @param modifiedConf the updated configurations
+   * @return the {@link Map} of properties which are newly added or have updated in the modifiedConf.
+   */
+  public static Map<String, String> getNonDefaultConfigurations(Configuration modifiedConf) {
+    MapDifference<String, String> mapDifference = Maps.difference(getConfigurationAsMap(new Configuration()),
+                                                                  getConfigurationAsMap(modifiedConf));
+    // new keys in the modified configurations
+    Map<String, String> newEntries = mapDifference.entriesOnlyOnRight();
+    // keys whose values got changed in the modified config
+    Map<String, MapDifference.ValueDifference<String>> stringValueDifferenceMap = mapDifference.entriesDiffering();
+    Map<String, String> result = new HashMap<>();
+    for (Map.Entry<String, MapDifference.ValueDifference<String>> stringValueDifferenceEntry :
+      stringValueDifferenceMap.entrySet()) {
+      result.put(stringValueDifferenceEntry.getKey(), stringValueDifferenceEntry.getValue().rightValue());
+    }
+    result.putAll(newEntries);
+    return result;
+  }
+
+  private static Map<String, String> getConfigurationAsMap(Configuration conf) {
+    Map<String, String> map = new HashMap<>();
+    for (Map.Entry<String, String> entry : conf) {
+      map.put(entry.getKey(), entry.getValue());
+    }
+    return map;
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/common/Constants.java
+++ b/src/main/java/co/cask/hydrator/plugin/common/Constants.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+/**
+ * Class that contains common names and description used across plugins.
+ */
+public final class Constants {
+
+  /**
+   * Common Reference Name property name and description
+   */
+  public static class Reference {
+    public static final String REFERENCE_NAME = "referenceName";
+    public static final String REFERENCE_NAME_DESCRIPTION = "This will be used to uniquely identify this source/sink " +
+      "for lineage, annotating metadata, etc.";
+  }
+
+  public static final String EXTERNAL_DATASET_TYPE = "externalDataset";
+
+  private Constants() {
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/common/IdUtils.java
+++ b/src/main/java/co/cask/hydrator/plugin/common/IdUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+import java.util.regex.Pattern;
+
+/**
+ * Utility class for Id related operations.
+ */
+public final class IdUtils {
+
+  private IdUtils() {
+  }
+
+  private static final Pattern datasetIdPattern = Pattern.compile("[$\\.a-zA-Z0-9_-]+");
+
+  public static void validateId(String id) throws IllegalArgumentException {
+    if (!datasetIdPattern.matcher(id).matches()) {
+      throw new IllegalArgumentException(String.format("%s is not a valid id. Allowed characters are letters, " +
+                                                         "numbers, and _, -, ., or $.", id));
+    }
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/common/JobUtils.java
+++ b/src/main/java/co/cask/hydrator/plugin/common/JobUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
+
+/**
+ * A utility for providing operations on {@link Job}.
+ */
+public final class JobUtils {
+
+  /**
+   * Creates a new instance of {@link Job}. Note that the job created is not meant for actual MR
+   * submission. It's just for setting up configurations.
+   */
+  public static Job createInstance() throws IOException {
+    Job job = Job.getInstance();
+
+    // some input formats require the credentials to be present in the job. We don't know for
+    // sure which ones (HCatalog is one of them), so we simply always add them. This has no other
+    // effect, because this method is only used at configure time and will be ignored later on.
+    if (UserGroupInformation.isSecurityEnabled()) {
+      Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
+      job.getCredentials().addAll(credentials);
+    }
+
+    return job;
+  }
+
+  private JobUtils() {
+    // no-op
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/common/ReferenceBatchSink.java
+++ b/src/main/java/co/cask/hydrator/plugin/common/ReferenceBatchSink.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+
+/**
+ * A {@link BatchSink} that verifies referenceName property
+ *
+ * @param <IN> the type of input object to the sink
+ * @param <KEY_OUT> the type of key the sink outputs
+ * @param <VAL_OUT> the type of value the sink outputs
+ */
+public abstract class ReferenceBatchSink<IN, KEY_OUT, VAL_OUT> extends BatchSink<IN, KEY_OUT, VAL_OUT> {
+  private final ReferencePluginConfig config;
+
+  public ReferenceBatchSink(ReferencePluginConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    // Verify that reference name meets dataset id constraints
+    IdUtils.validateId(config.referenceName);
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/common/ReferenceBatchSource.java
+++ b/src/main/java/co/cask/hydrator/plugin/common/ReferenceBatchSource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchSource;
+
+/**
+ * A {@link BatchSource} that verifies referenceName property
+ *
+ * @param <KEY_IN> the type of input key from the Batch run
+ * @param <VAL_IN> the type of input value from the Batch run
+ * @param <OUT> the type of output for the source
+ */
+public abstract class ReferenceBatchSource<KEY_IN, VAL_IN, OUT> extends BatchSource<KEY_IN, VAL_IN, OUT> {
+  private final ReferencePluginConfig config;
+
+  public ReferenceBatchSource(ReferencePluginConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    // Verify that reference name meets dataset id constraints
+    IdUtils.validateId(config.referenceName);
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/common/ReferencePluginConfig.java
+++ b/src/main/java/co/cask/hydrator/plugin/common/ReferencePluginConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.plugin.PluginConfig;
+
+/**
+ * {@link PluginConfig} that contains a referenceName property that is used to create an external Dataset for
+ * metadata, lineage purposes.
+ */
+public class ReferencePluginConfig extends PluginConfig {
+
+  @Name(Constants.Reference.REFERENCE_NAME)
+  @Description(Constants.Reference.REFERENCE_NAME_DESCRIPTION)
+  public String referenceName;
+
+  public ReferencePluginConfig(String referenceName) {
+    this.referenceName = referenceName;
+  }
+}

--- a/src/main/java/co/cask/hydrator/plugin/common/SourceInputFormatProvider.java
+++ b/src/main/java/co/cask/hydrator/plugin/common/SourceInputFormatProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+import co.cask.cdap.api.data.batch.InputFormatProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputFormat;
+
+import java.util.Map;
+
+/**
+ * An implementation of {@link InputFormatProvider} based on {@link Configuration} and input format class.
+ */
+public final class SourceInputFormatProvider implements InputFormatProvider {
+
+  private final String inputFormatClassName;
+  private final Map<String, String> configuration;
+
+  public SourceInputFormatProvider(Class<? extends InputFormat> inputFormatClass, Configuration hConf) {
+    this(inputFormatClass.getName(), hConf);
+  }
+
+  public SourceInputFormatProvider(String inputFormatClassName, Configuration hConf) {
+    this.inputFormatClassName = inputFormatClassName;
+    this.configuration = ConfigurationUtils.getNonDefaultConfigurations(hConf);
+  }
+
+  @Override
+  public String getInputFormatClassName() {
+    return inputFormatClassName;
+  }
+
+  @Override
+  public Map<String, String> getInputFormatConfiguration() {
+    return configuration;
+  }
+}

--- a/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataTest.java
+++ b/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+
+import co.cask.hydrator.plugin.batch.file.s3.S3FileMetadata;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AbstractFileMetadataTest {
+  @Test
+  public void testConvertFileStatusToFileMetaData() throws IOException {
+    FileStatus fileStatus = new FileStatus();
+    fileStatus.setPath(new Path("s3a://abc.def.bucket/source/path/directory/123.txt"));
+
+    // Copy a file that is part of a whole directory copy
+    String sourcePath = "/source/path/directory";
+    S3FileMetadata metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
+    Assert.assertEquals(metadata.getFileName(), "123.txt");
+    Assert.assertEquals(metadata.getFullPath(), "/source/path/directory/123.txt");
+    Assert.assertEquals(metadata.getRelativePath(), "directory/123.txt");
+    Assert.assertEquals(metadata.getHostURI(), "s3a://abc.def.bucket");
+
+    // Copy a file that is part of a whole directory copy without including the directory
+    sourcePath = "/source/path/";
+    metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
+    Assert.assertEquals(metadata.getFileName(), "123.txt");
+    Assert.assertEquals(metadata.getFullPath(), "/source/path/directory/123.txt");
+    Assert.assertEquals(metadata.getRelativePath(), "directory/123.txt");
+    Assert.assertEquals(metadata.getHostURI(), "s3a://abc.def.bucket");
+
+    fileStatus.setPath(new Path("s3a://abc.def.bucket/"));
+    sourcePath = "/";
+    metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
+    Assert.assertEquals(metadata.getRelativePath().isEmpty(), true);
+
+    fileStatus.setPath(new Path("s3a://abc.def.bucket/abc.txt"));
+    sourcePath = "/";
+    metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
+    Assert.assertEquals(metadata.getRelativePath(), "abc.txt");
+  }
+
+  @Test
+  public void testCompare() throws IOException {
+    final FileStatus statusA = new FileStatus(1, false, 0, 0, 0, new Path("s3a://hello.com/abc/fileA"));
+    final FileStatus statusB = new FileStatus(3, false, 0, 0, 0, new Path("s3a://hello.com/abc/fileB"));
+    final FileStatus statusC = new FileStatus(3, false, 0, 0, 0, new Path("s3a://hello.com/abc/fileC"));
+    final String basePath = "/abc";
+
+    // generate 3 files with different file sizes
+    S3FileMetadata file1 = new S3FileMetadata(statusA, basePath, null, null, null);
+
+    S3FileMetadata file2 = new S3FileMetadata(statusB, basePath, null, null, null);
+
+    S3FileMetadata file3 = new S3FileMetadata(statusC, basePath, null, null, null);
+
+    Assert.assertEquals(file1.compareTo(file2), -1);
+    Assert.assertEquals(file3.compareTo(file2), 0);
+    Assert.assertEquals(file3.compareTo(file1), 1);
+  }
+}

--- a/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplitTest.java
+++ b/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplitTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import co.cask.hydrator.plugin.batch.file.s3.S3FileMetadata;
+import co.cask.hydrator.plugin.batch.file.s3.S3MetadataInputSplit;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class AbstractMetadataInputSplitTest {
+  @Test
+  public void testSerializeAndDeserialize() throws Exception {
+    // required for abstract metadata
+    final long lengthA = 101;
+    final long lengthB = 202;
+    final boolean isdir = false;
+    final int blockReplication = 0;
+    final long blocksize = 0;
+    final long modificationTime = 12345678;
+    final long accessTime = 87654321;
+    final FsPermission permission = new FsPermission((short) 166);
+    final String owner  = "someOwner";
+    final String group = "someGroup";
+    final Path path = new Path("s3a://abc.def.ghi/foo/bar/baz/123.txt");
+    final String sourcePath = "/foo/bar";
+
+    // required for s3metadata
+    final String accessKeyId = "akey";
+    final String secretKeyId = "skey";
+    final String region = "us-east-1";
+
+    // initialize an inputSplit
+    FileStatus fileStatusA = new FileStatus(lengthA, isdir, blockReplication, blocksize,
+                                           modificationTime, accessTime, permission, owner, group, path);
+    FileStatus fileStatusB = new FileStatus(lengthB, isdir, blockReplication, blocksize,
+                                            modificationTime, accessTime, permission, owner, group, path);
+    S3FileMetadata originalMetadataA = new S3FileMetadata(fileStatusA, sourcePath, accessKeyId, secretKeyId, region);
+    S3FileMetadata originalMetadataB = new S3FileMetadata(fileStatusB, sourcePath, accessKeyId, secretKeyId, region);
+    S3MetadataInputSplit metadataInputSplit = new S3MetadataInputSplit();
+    metadataInputSplit.addFileMetadata(originalMetadataA);
+    metadataInputSplit.addFileMetadata(originalMetadataB);
+
+    // serialize input split
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream outputStream = new DataOutputStream(byteArrayOutputStream);
+    metadataInputSplit.write(outputStream);
+    outputStream.flush();
+    outputStream.close();
+    byte[] serialized = byteArrayOutputStream.toByteArray();
+
+    // deserialize input split
+    S3MetadataInputSplit recoveredInputSplit = new S3MetadataInputSplit();
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(serialized);
+    DataInputStream inputStream = new DataInputStream(byteArrayInputStream);
+    recoveredInputSplit.readFields(inputStream);
+    inputStream.close();
+
+    // compare if split size is right
+    Assert.assertEquals(metadataInputSplit.getLength(), recoveredInputSplit.getLength());
+    Assert.assertEquals(metadataInputSplit.getTotalBytes(), recoveredInputSplit.getTotalBytes());
+
+    // compare if recovered fileMetadata is right
+    Assert.assertEquals(recoveredInputSplit.getFileMetaDataList().get(0).toRecord(),
+                        metadataInputSplit.getFileMetaDataList().get(0).toRecord());
+    Assert.assertEquals(recoveredInputSplit.getFileMetaDataList().get(1).toRecord(),
+                        metadataInputSplit.getFileMetaDataList().get(1).toRecord());
+  }
+
+  @Test
+  public void testCompare() throws IOException {
+    S3MetadataInputSplit metadataInputSplita = new S3MetadataInputSplit();
+    S3MetadataInputSplit metadataInputSplitb = new S3MetadataInputSplit();
+    S3MetadataInputSplit metadataInputSplitc = new S3MetadataInputSplit();
+
+    final FileStatus statusA = new FileStatus(1, false, 0, 0, 0, new Path("s3a://hello.com/abc/fileA"));
+    final FileStatus statusB = new FileStatus(2, false, 0, 0, 0, new Path("s3a://hello.com/abc/fileB"));
+    final FileStatus statusC = new FileStatus(3, false, 0, 0, 0, new Path("s3a://hello.com/abc/fileC"));
+    final String basePath = "/abc";
+
+    // required for s3metadata
+    final String accessKeyId = "akey";
+    final String secretKeyId = "skey";
+    final String region = "us-east-1";
+
+    // generate 3 files with different file sizes
+    S3FileMetadata file1 = new S3FileMetadata(statusA, basePath, accessKeyId, secretKeyId, region);
+
+    S3FileMetadata file2 = new S3FileMetadata(statusB, basePath, accessKeyId, secretKeyId, region);
+
+    S3FileMetadata file3 = new S3FileMetadata(statusC, basePath, accessKeyId, secretKeyId, region);
+
+    // a has 3 bytes
+    metadataInputSplita.addFileMetadata(file1);
+    metadataInputSplita.addFileMetadata(file2);
+
+    // b has 3 bytes too
+    metadataInputSplitb.addFileMetadata(file3);
+
+    // c only has 1 byte
+    metadataInputSplitc.addFileMetadata(file1);
+
+    Assert.assertEquals(metadataInputSplita.compareTo(metadataInputSplitb), 0);
+    Assert.assertEquals(metadataInputSplita.compareTo(metadataInputSplitc), 1);
+    Assert.assertEquals(metadataInputSplitc.compareTo(metadataInputSplita), -1);
+  }
+}

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright © 2014-2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+  <suppress checks="Javadoc.*" files=".*[/\\]src[/\\]test[/\\]java[/\\].*" />
+
+  <suppress checks="JavadocPackage" files=".*[/\\]src[/\\](main|integration)[/\\]java[/\\].*" />
+  <suppress checks="JavadocPackage" files=".*[/\\]src[/\\].*[/\\]internal[/\\].*" />
+
+  <suppress checks="JavadocStyle" files=".*[/\\]src[/\\](main|integration)[/\\]java[/\\].*" />
+  <suppress checks="JavadocStyle" files=".*[/\\]src[/\\].*[/\\]internal[/\\].*" />
+
+  <suppress checks="RedundantModifier" files=".*[/\\]src[/\\]test[/\\]java[/\\].*" />
+
+
+  <!-- copied from apache hadoop, won't fix style to keep diff minimal -->
+  <suppress checks=".*" files=".*[/\\]LocalJobRunnerWithFix.java" />
+
+  <!-- do not check thrift generated files -->
+  <suppress checks=".*" files=".*[/\\]transaction[/\\]distributed[/\\]thrift[/\\].*" />
+
+  <suppress checks=".*" files=".*[/\\]src[/\\](main)[/\\](thrift)[/\\].*" />
+  <suppress checks=".*" files=".*[/\\]src[/\\](main)[/\\](java)[/\\](co|org)[/\\](cask|apache)[/\\](tephra|thrift)[/\\].*" />
+
+</suppressions>

--- a/widgets/HDFSFileCopySink-batchsink.json
+++ b/widgets/HDFSFileCopySink-batchsink.json
@@ -1,0 +1,52 @@
+{
+  "metadata": {
+    "spec-version": "1.3"
+  },
+  "configuration-groups": [
+    {
+      "label": "HDFS File Copy Sink",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Reference Name",
+          "name": "referenceName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Base Path",
+          "name": "basePath"
+        },
+        {
+          "widget-type": "select",
+          "label": "Enable Overwrite",
+          "name": "enableOverwrite",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Preserve File Owner",
+          "name": "preserveFileOwner",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Buffer Size (MB)",
+          "name": "bufferSize",
+          "default": "1"
+        }
+      ]
+    }
+  ]
+}

--- a/widgets/S3FileMetadataSource-batchsource.json
+++ b/widgets/S3FileMetadataSource-batchsource.json
@@ -1,0 +1,143 @@
+{
+  "metadata": {
+    "spec-version": "1.3"
+  },
+  "configuration-groups": [
+    {
+      "label": "S3 File Copy Source",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Reference Name",
+          "name": "referenceName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "URI",
+          "name": "filesystemURI"
+        },
+        {
+          "widget-type": "csv",
+          "label": "Source Paths",
+          "name": "sourcePaths"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Max Split Size",
+          "name": "maxSplitSize"
+        },
+        {
+          "widget-type": "select",
+          "label": "Copy Recursively",
+          "name": "recursiveCopy",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "true"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Access Key ID",
+          "name": "accessKeyId"
+        },
+        {
+          "widget-type": "password",
+          "label": "Secret Key ID",
+          "name": "secretKeyId"
+        },
+        {
+          "widget-type": "select",
+          "label": "Amazon Region",
+          "name": "region",
+          "widget-attributes": {
+            "values": [
+              "us-gov-west-1",
+              "us-east-1",
+              "us-east-2",
+              "us-west-1",
+              "us-west-2",
+              "eu-west-1",
+              "eu-west-2",
+              "eu-central-1",
+              "ap-south-1",
+              "ap-southeast-1",
+              "ap-southeast-2",
+              "ap-northeast-1",
+              "ap-northeast-2",
+              "sa-east-1",
+              "cn-north-1",
+              "ca-central-1"
+            ],
+            "default": "us-east-1"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "widget-type": "non-editable-schema-editor",
+      "schema": {
+        "name": "etlSchemaBody",
+        "type": "record",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": "string"
+          },
+          {
+            "name": "fullPath",
+            "type": "string"
+          },
+          {
+            "name": "fileSize",
+            "type": "long"
+          },
+          {
+            "name": "modificationTime",
+            "type": "long"
+          },
+          {
+            "name": "group",
+            "type": "string"
+          },
+          {
+            "name": "owner",
+            "type": "string"
+          },
+          {
+            "name": "isFolder",
+            "type": "boolean"
+          },
+          {
+            "name": "relativePath",
+            "type": "string"
+          },
+          {
+            "name": "permission",
+            "type": "int"
+          },
+          {
+            "name": "hostURI",
+            "type": "string"
+          },
+          {
+            "name": "accessKeyID",
+            "type": "string"
+          },
+          {
+            "name": "secretKeyID",
+            "type": "string"
+          },
+          {
+            "name": "region",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
1. S3FileMetadataSource: a batch source that reads file metadata from
   Amazon S3 filesystems using AbstractMetadataInputFormat
2. HDFSFileCopySink: a batch sink that takes file metadata as inputs
   and copies data from source filesystem to local hdfs.
3. This pull request is a clone of https://github.com/caskdata/hydrator-plugins/pull/693