### PR TITLE
[CDAP-13364] Fix whole-file-ingest source: 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <name>Whole File Ingest Plugins</name>
   <groupId>co.cask.hydrator</groupId>
   <artifactId>whole-file-ingest</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -66,6 +66,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>4.3.0</cdap.version>
     <hadoop.version>2.8.1</hadoop.version>
+    <guava.version>13.0.1</guava.version>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
   </properties>
@@ -86,6 +87,7 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${cdap.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
@@ -96,13 +98,19 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-core</artifactId>
-      <scope>provided</scope>
       <version>${hadoop.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-aws</artifactId>
       <version>${hadoop.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyRecordWriter.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyRecordWriter.java
@@ -100,7 +100,7 @@ public class FileCopyRecordWriter extends RecordWriter<NullWritable, FileMetadat
     // construct file paths for source and destination
     Path srcPath = new Path(fileMetadata.getFullPath());
     Path destPath = new Path(basePath, fileMetadata.getRelativePath());
-    FsPermission permission = new FsPermission(fileMetadata.getPermission());
+    FsPermission permission = new FsPermission((short) fileMetadata.getPermission());
 
     // immediately return if we don't want to overwrite and file exists in destination
     if (!enableOverwrite && destFileSystem.exists(destPath)) {

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/FileMetadata.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/FileMetadata.java
@@ -20,8 +20,6 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -55,7 +53,7 @@ public class FileMetadata implements Comparable {
     Schema.Field.of(FULL_PATH, Schema.of(Schema.Type.STRING)),
     Schema.Field.of(FILE_SIZE, Schema.of(Schema.Type.LONG)),
     Schema.Field.of(MODIFICATION_TIME, Schema.of(Schema.Type.LONG)),
-    Schema.Field.of(GROUP, Schema.of(Schema.Type.LONG)),
+    Schema.Field.of(GROUP, Schema.of(Schema.Type.STRING)),
     Schema.Field.of(OWNER, Schema.of(Schema.Type.STRING)),
     Schema.Field.of(IS_DIR, Schema.of(Schema.Type.BOOLEAN)),
     Schema.Field.of(RELATIVE_PATH, Schema.of(Schema.Type.STRING)),
@@ -98,15 +96,13 @@ public class FileMetadata implements Comparable {
   private final String relativePath;
 
   // file permission, encoded in short
-  private final short permission;
+  private final int permission;
 
   /*
    * URI for the Filesystem
    * For instance, the hostURI for http://abc.def.ghi/new/index.html is http://abc.def.ghi
    */
   private final String hostURI;
-
-  private static final Logger LOG = LoggerFactory.getLogger(FileMetadata.class);
 
   /**
    * Constructs a FileMetadata instance given a FileStatus and source path. Override this method to add additional
@@ -175,7 +171,7 @@ public class FileMetadata implements Comparable {
     this.fileSize = dataInput.readLong();
     this.isDir = dataInput.readBoolean();
     this.relativePath = dataInput.readUTF();
-    this.permission = dataInput.readShort();
+    this.permission = dataInput.readInt();
     this.hostURI = dataInput.readUTF();
   }
 
@@ -211,7 +207,7 @@ public class FileMetadata implements Comparable {
     return relativePath;
   }
 
-  public short getPermission() {
+  public int getPermission() {
     return permission;
   }
 
@@ -275,7 +271,7 @@ public class FileMetadata implements Comparable {
     dataOutput.writeLong(getFileSize());
     dataOutput.writeBoolean(isDir());
     dataOutput.writeUTF(getRelativePath());
-    dataOutput.writeShort(getPermission());
+    dataOutput.writeInt(getPermission());
     dataOutput.writeUTF(getHostURI());
   }
 

--- a/src/main/java/co/cask/hydrator/plugin/batch/file/fs/FileCopySink.java
+++ b/src/main/java/co/cask/hydrator/plugin/batch/file/fs/FileCopySink.java
@@ -24,13 +24,13 @@ import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.hydrator.plugin.batch.file.AbstractFileCopySink;
 import co.cask.hydrator.plugin.batch.file.FileCopyOutputFormat;
-import com.sun.istack.Nullable;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import javax.annotation.Nullable;
 
 /**
  * FileCopySink that writes to local filesystem or local HDFS.


### PR DESCRIPTION
- exclude hadoop and cdap dependencies from artifact; 
- fix schema type errors for group name and permissions;
- fix wrong import for @Nullable
- bump version to 1.1.0