### PR TITLE
Updating CDAP version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.4.1</cdap.version>
     <hadoop.version>2.8.1</hadoop.version>
-    <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
+    <hydrator.version>2.6.1</hydrator.version>
     <guava.version>13.0.1</guava.version>
   </properties>
 


### PR DESCRIPTION
It is not possible to build the plugin with the SNAPSHOT dependency on CDAP. I updated to 6.4.1.